### PR TITLE
License key/software template improvements

### DIFF
--- a/src/components/Code.jsx
+++ b/src/components/Code.jsx
@@ -21,8 +21,8 @@ const languageNames = {
   python: 'Python',
   ruby: 'Ruby',
   go: 'Go',
-  text: 'membership.went_valid',
-  xml: 'payment.succeeded',
+  text: 'text',
+  xml: 'XML',
 }
 
 function getPanelTitle({ title, language }) {

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -238,8 +238,8 @@ export const navigation = [
       { title: 'Getting started', href: '/software-intro' },
       { title: 'Webhooks', href: '/webhook' },
       { title: 'License key integration', href: '/license-key' },
-      { title: 'Templates', href: '/software-templates' },
       { title: 'Software FAQ', href: '/software-faq' },
+      { title: 'Templates', href: '/software-templates' },
       { title: 'TypeScript SDK', href: '/ts-sdk' },
       {
         title: 'API reference',

--- a/src/pages/license-key.mdx
+++ b/src/pages/license-key.mdx
@@ -2,40 +2,160 @@ import { CodeGroup } from '../components/Code'
 
 # License Key Integration
 
-When users purchase access to products on Whop, they are given a license key. In your software, you can require your users to enter a license key in order to use your software.
+Whop provides a seamless user experience for purchasing and accessing products. After purchasing a product, users are granted a unique license key that they can use to access and unlock their purchased product. As a developer, you can integrate this feature into your own software by requiring your users to enter their license key before being granted access to the product, or gate certain features of the application behind validating the current license key. This approach not only ensures that only licensed users can use your software, but also enhances security and prevents unauthorized access.
 
-## Setting up on the Whop dashboard
+## Getting started
 
-After you have created your company, create a product and add a license key to the product via your dashboard.
+If you haven't already [created your company](/creating-company) or [made a product to sell](/creating-company#creating-your-first-product), you'll want to start there.
 
+Once you've done that, head to the dashboard to add the license key capability to your product.
 ![License Key Setup](https://i.imgur.com/77Bkxbl.gif){{ className: 'rounded-lg w-full' }}
 
 ## Integrating with your product
 
-After you've added the license key capability to your product, Whop's API makes it incredibly easy to validate a user's license key.
+When integrating Whop's API into your software, you can validate license keys to ensure that only licensed users can access your products. Here's how the key validation process works:
+
+- **Validating Empty Metadata**: If the metadata on the license key is empty (for example, the key is not yet bound to a computer), Whop's API returns a success response with status code 201. This means that the license key is valid and can be used to access the product. Internally, the API sets the metadata of the license key that was passed in the API call.
 
 <CodeGroup
-  title="Validate a License Key"
+title="Validating Empty Metadata"
+tag="POST"
+label="memberships/:id/validate_license"
+>
+
+```js
+import axios from 'axios'
+
+const checkAccess = async (accessPassId, accessToken) => {
+  try {
+    const response = await axios.post(
+      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          metadata: {
+            key: 'value', // This is initially setting the key/value pair if it doesn't already exist
+          },
+        },
+      }
+    )
+    return response.data
+  } catch (error) {
+    throw error
+  }
+}
+
+export default checkAccess
+```
+
+</CodeGroup>
+
+- **Validating Matching Metadata**: If the metadata on the license key is already set, and it matches the metadata that your software sends to Whop's API, then a success response is returned. This means that the license key is valid and can be used to access the product. Whop's API checks every key value pair in the metadata, ensuring that all fields contain the same data.
+
+<CodeGroup
+title="Validating Matching Metadata"
+tag="POST"
+label="memberships/:id/validate_license"
+>
+
+```js
+import axios from 'axios'
+
+const checkAccess = async (accessPassId, accessToken) => {
+  try {
+    const response = await axios.post(
+      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          metadata: {
+            key: 'value', // This is now checking the key/value pair
+          },
+        },
+      }
+    )
+  } catch (error) {
+    throw error
+  }
+}
+
+export default checkAccess
+```
+
+</CodeGroup>
+
+- **Validating Mismatched Metadata**: If the metadata on the license key is set, but the metadata fields do not match the metadata that your software sends to Whop's API, a failure response with status code 400 is returned. This means that the license key is not valid and cannot be used to access the product.
+
+<CodeGroup
+  title="Validating Mismatched Metadata"
   tag="POST"
   label="memberships/:id/validate_license"
 >
-  ```js
-    import axios from 'axios';
 
-    const checkAccess = async (accessPassId, accessToken) => {
-        try {
-            const response = await axios.get(`https://api.whop.com/api/v2/memberships/${id}/validate_license`, {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            });
-            return response.data;
-        } catch (error) {
-            throw error;
-        }
-    };
+```js
+import axios from 'axios'
 
-    export default checkAccess;
-    ```
+const checkAccess = async (accessPassId, accessToken) => {
+  try {
+    const response = await axios.post(
+      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          metadata: {
+            wrongKey: 'wrongValue', // Different key/value pair than what is set on the license
+          },
+        },
+      }
+    )
+    return response.data // Error is expected here
+  } catch (error) {
+    throw error
+  }
+}
+
+export default checkAccess
+```
+
+</CodeGroup>
+
+- **Removing Metadata**: Users can reset their key's metadata by going to their hub, but you can also programatically call the `validate_license` endpoint with an empty metadata body to reset the key as well.
+
+<CodeGroup
+  title="Removing Metadata"
+  tag="POST"
+  label="memberships/:id/validate_license"
+>
+
+```js
+import axios from 'axios'
+
+const checkAccess = async (accessPassId, accessToken) => {
+  try {
+    const response = await axios.post(
+      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          metadata: {}, // Removes previously set metadata
+        },
+      }
+    )
+    return response.data
+  } catch (error) {
+    throw error
+  }
+}
+
+export default checkAccess
+```
 
 </CodeGroup>

--- a/src/pages/license-key.mdx
+++ b/src/pages/license-key.mdx
@@ -136,7 +136,7 @@ export default checkAccess
 ```js
 import axios from 'axios'
 
-const checkAccess = async (accessPassId, accessToken) => {
+const removeAccess = async (accessPassId, accessToken) => {
   try {
     const response = await axios.post(
       `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
@@ -155,7 +155,7 @@ const checkAccess = async (accessPassId, accessToken) => {
   }
 }
 
-export default checkAccess
+export default removeAccess
 ```
 
 </CodeGroup>

--- a/src/pages/license-key.mdx
+++ b/src/pages/license-key.mdx
@@ -15,10 +15,12 @@ Once you've done that, head to the dashboard to add the license key capability t
 
 When integrating Whop's API into your software, you can validate license keys to ensure that only licensed users can access your products. Here's how the key validation process works:
 
-- **Validating Empty Metadata**: If the metadata on the license key is empty (for example, the key is not yet bound to a computer), Whop's API returns a success response with status code 201. This means that the license key is valid and can be used to access the product. Internally, the API sets the metadata of the license key that was passed in the API call.
+### Initially Setting the Metadata
+
+If the metadata on the license key is empty (for example, the key is not yet bound to a computer), Whop's API returns a success response with status code `201`. This means that the license key is valid and can be used to access the product. Internally, the API sets the metadata of the license key that was passed in the API call.
 
 <CodeGroup
-title="Validating Empty Metadata"
+title="Initially Setting the Metadata"
 tag="POST"
 label="memberships/:id/validate_license"
 >
@@ -52,110 +54,50 @@ export default checkAccess
 
 </CodeGroup>
 
-- **Validating Matching Metadata**: If the metadata on the license key is already set, and it matches the metadata that your software sends to Whop's API, then a success response is returned. This means that the license key is valid and can be used to access the product. Whop's API checks every key value pair in the metadata, ensuring that all fields contain the same data.
+### Validating Matching Metadata
 
-<CodeGroup
-title="Validating Matching Metadata"
-tag="POST"
-label="memberships/:id/validate_license"
->
+If the metadata on the license key is already set, and it matches the metadata that your software sends to Whop's API, then a success response is returned. This means that the license key is valid and can be used to access the product. Whop's API checks every key value pair in the metadata, ensuring that all fields contain the same data.
 
-```js
-import axios from 'axios'
+Below is example metadata that would return a successful response.
 
-const checkAccess = async (accessPassId, accessToken) => {
-  try {
-    const response = await axios.post(
-      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: {
-          metadata: {
-            key: 'value', // This is now checking the key/value pair
-          },
-        },
-      }
-    )
-  } catch (error) {
-    throw error
-  }
+**Client-side**
+
+```json
+{
+  "hwid": "098H52ST479QE053V2"
 }
-
-export default checkAccess
 ```
 
-</CodeGroup>
+**Server-side**
 
-- **Validating Mismatched Metadata**: If the metadata on the license key is set, but the metadata fields do not match the metadata that your software sends to Whop's API, a failure response with status code 400 is returned. This means that the license key is not valid and cannot be used to access the product.
-
-<CodeGroup
-  title="Validating Mismatched Metadata"
-  tag="POST"
-  label="memberships/:id/validate_license"
->
-
-```js
-import axios from 'axios'
-
-const checkAccess = async (accessPassId, accessToken) => {
-  try {
-    const response = await axios.post(
-      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: {
-          metadata: {
-            wrongKey: 'wrongValue', // Different key/value pair than what is set on the license
-          },
-        },
-      }
-    )
-    return response.data // Error is expected here
-  } catch (error) {
-    throw error
-  }
+```json
+{
+  "hwid": "098H52ST479QE053V2"
 }
-
-export default checkAccess
 ```
 
-</CodeGroup>
+### Validating Mismatched Metadata
 
-- **Removing Metadata**: Users can reset their key's metadata by going to their hub, but you can also programatically call the `validate_license` endpoint with an empty metadata body to reset the key as well.
+If the metadata on the license key is set, but the metadata fields do not match the metadata that your software sends to Whop's API, a failure response with status code `400` is returned. This means that the license key is not valid and cannot be used to access the product.
 
-<CodeGroup
-  title="Removing Metadata"
-  tag="POST"
-  label="memberships/:id/validate_license"
->
+Below is example metadata that would return this error.
 
-```js
-import axios from 'axios'
+**Client-side**
 
-const removeAccess = async (accessPassId, accessToken) => {
-  try {
-    const response = await axios.post(
-      `https://api.whop.com/api/v2/memberships/${id}/validate_license`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: {
-          metadata: {}, // Removes previously set metadata
-        },
-      }
-    )
-    return response.data
-  } catch (error) {
-    throw error
-  }
+```json
+{
+  "hwid": "30294GLDKJ54F0SLKF"
 }
-
-export default removeAccess
 ```
 
-</CodeGroup>
+**Server-side**
+
+```json
+{
+  "hwid": "098H52ST479QE053V2"
+}
+```
+
+### Removing Metadata
+
+Users can reset their key's metadata by going to their hub, but you can also programatically call the `validate_license` endpoint with an empty metadata body to reset the key as well.

--- a/src/pages/software-templates.mdx
+++ b/src/pages/software-templates.mdx
@@ -1,15 +1,17 @@
 # Templates
 
-Here are some resources to get you started.
+Here, you'll find a collection of boilerplate code templates that can help you get started quickly with building applications using Whop's API. These templates are designed to save you time and effort by providing pre-written code for common tasks, such as authentication, data retrieval, and error handling. Whether you're a seasoned developer or just starting out with Whop's API, these templates can help you build robust and efficient applications.
 
 ## Next.js starter app
 
-A simple way to sell access to your Next.js App.
+[Deploy on Vercel](https://vercel.com/templates/next.js/whop-template) | [View on GitHub](https://github.com/whopio/next-template)
 
-https://vercel.com/templates/next.js/whop-template
+Our Next.js boilerplate for Whop's API integration is a comprehensive solution for beginning to sell access to dynamic and performant web applications. This boilerplate is designed to showcase how to utilize the latest features from both version 12 and version 13 of Next.js.
 
-## Fully integrated app
+The template uses all components of the Next.js ecosystem, including the new `pages` directory in v13, as well as using both server-side rendering as well as static generation of content.
 
-See whats possible with this fully integrated example.
+## Fully integrated Next.js application
 
-View the [repo](https://github.com/whopio/readpilot)
+[View the demo](readpilot-gamma.vercel.app/) | [View the GitHub](https://github.com/whopio/readpilot)
+
+This repository is a fork of Index Lab's ReadPilot application, but using Whop's OAuth and payment flow to gate access to the application. This is a fantastic example if you want to demo a live version of the checkout flow of Whop and see what it could look like in your application.


### PR DESCRIPTION
- Rewrote entire license key implementation page with more detailed examples of the validate_license endpoint
- Rewrote software template page to highlight the actual features of each template better
- Fixed odd bug with `CodeGroup` component